### PR TITLE
HTML entity encode the title

### DIFF
--- a/web/rss.php
+++ b/web/rss.php
@@ -48,7 +48,7 @@ header( 'Content-Type: application/rss+xml;' );
         while( $post = $PDO->fetch() ) :
             ?>
             <item>
-                <title><?php echo $post->topic; ?></title>
+                <title><?php echo htmlentities($post->topic); ?></title>
                 <description><![CDATA[<?php echo $post->content; ?>]]></description>
                 <link><?php echo $post->url; ?></link>
                 <guid><?php echo $post->url; ?></guid>


### PR DESCRIPTION
Title's with `&` or other HTML-special characters cause some RSS parsers to fail. This should resolve that.

Description's CDATA wrapper should cover that fine. I don't think link, guid or pubDate are likely to have issues. So only touching title here.