### PR TITLE
Redeploy hourly so newly-populated games go live without a commit

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - master
+  # Rebuild + redeploy hourly so a game that only just gained posts (and was
+  # therefore skipped by build.js's zero-post filter on the last run) goes live
+  # without waiting for the next commit.
+  schedule:
+    - cron: '0 * * * *'
 
 jobs:
   deploy:
@@ -20,16 +25,75 @@ jobs:
 
     - run: npm ci
 
-    - run: npm run build
+    # Fingerprint the set of games that currently have posts (same filter the
+    # build applies). On scheduled runs we use this to skip an identical
+    # rebuild/redeploy when nothing changed, so hourly runs don't churn the
+    # service-worker / re-upload for every visitor when there's nothing new.
+    # Push and manual runs always deploy regardless.
+    - name: Fingerprint published games
+      id: fingerprint
+      env:
+        API_TOKEN: ${{ secrets.API_TOKEN }}
+      run: |
+        if fp=$(node scripts/games-fingerprint.js); then
+          echo "value=$fp" >> "$GITHUB_OUTPUT"
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+          echo "Games fingerprint: $fp"
+        else
+          # Fail-safe: if we can't compute the fingerprint, don't skip — fall
+          # through to a normal deploy.
+          echo "ok=false" >> "$GITHUB_OUTPUT"
+          echo "Fingerprint unavailable; will deploy unconditionally."
+        fi
+
+    # Cross-run state: a cache under this exact key exists only if a previous
+    # run already deployed this same set of games. A hit therefore means
+    # "nothing to do".
+    - name: Check for prior deploy of this game set
+      id: fpcache
+      if: steps.fingerprint.outputs.ok == 'true'
+      uses: actions/cache@v4
+      with:
+        path: .games-fingerprint
+        key: games-fingerprint-${{ steps.fingerprint.outputs.value }}
+
+    # Skip the deploy only on scheduled runs where the game set is unchanged
+    # (cache hit). Any other event, a fingerprint failure, or a cache miss
+    # proceeds to deploy.
+    - name: Decide whether to deploy
+      id: gate
+      run: |
+        if [ "${{ github.event_name }}" = "schedule" ] \
+           && [ "${{ steps.fingerprint.outputs.ok }}" = "true" ] \
+           && [ "${{ steps.fpcache.outputs.cache-hit }}" = "true" ]; then
+          echo "deploy=false" >> "$GITHUB_OUTPUT"
+          echo "Scheduled run, game set unchanged — skipping deploy."
+        else
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+          echo "Deploying."
+        fi
+
+    - name: Build
+      if: steps.gate.outputs.deploy == 'true'
+      run: npm run build
 
     - name: Generate static site
+      if: steps.gate.outputs.deploy == 'true'
       run: node scripts/build.js
       env:
         API_TOKEN: ${{ secrets.API_TOKEN }}
 
     - name: Deploy to Cloudflare Pages
+      if: steps.gate.outputs.deploy == 'true'
       uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: pages deploy
+
+    # Record the fingerprint we just deployed so the cache key gets saved at
+    # job end (only saved on a cache miss, i.e. the first time we deploy this
+    # set). This is what makes the next scheduled run able to skip.
+    - name: Record deployed fingerprint
+      if: steps.gate.outputs.deploy == 'true' && steps.fingerprint.outputs.ok == 'true'
+      run: echo "${{ steps.fingerprint.outputs.value }}" > .games-fingerprint

--- a/scripts/games-fingerprint.js
+++ b/scripts/games-fingerprint.js
@@ -1,0 +1,167 @@
+/* eslint-disable no-sync */
+// Emits a stable fingerprint (sha256) of the set of games that currently
+// qualify for the site: those the API knows about AND that have at least one
+// post. This mirrors the zero-post filter in build.js so the scheduled
+// workflow can cheaply answer "has the published set of games changed since
+// the last deploy?" and skip an otherwise-identical rebuild/redeploy.
+//
+// Prints the hex digest to stdout (nothing else) so a workflow step can
+// capture it. Any failure prints nothing and exits non-zero, which the caller
+// treats as "can't tell -> deploy anyway" (fail safe, never skip on error).
+// quiet: true so dotenv's tip banner doesn't land on stdout — this script's
+// stdout must be the bare digest and nothing else (the workflow captures it).
+require( 'dotenv' ).config( { quiet: true } );
+
+const https = require( 'https' );
+const url = require( 'url' );
+const crypto = require( 'crypto' );
+
+if ( !process.env.API_TOKEN ) {
+    throw new Error( 'Unable to load api key' );
+}
+
+const API_HOST = 'api.developertracker.com';
+const MAX_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = 1000;
+const REQUEST_TIMEOUT_MS = 60000;
+const REQUEST_CONCURRENCY = 6;
+
+const sleep = function sleep( ms ) {
+    return new Promise( ( resolve ) => {
+        setTimeout( resolve, ms );
+    } );
+};
+
+const attemptGet = function attemptGet( requestUrl, headers = false ) {
+    return new Promise( ( resolve, reject ) => {
+        let httpsGet = requestUrl;
+        if ( headers ) {
+            const urlParts = url.parse( requestUrl );
+
+            httpsGet = {
+                headers: headers,
+                hostname: urlParts.hostname,
+                path: urlParts.path,
+                port: urlParts.port || 443,
+            };
+        }
+
+        const request = https.get( httpsGet, ( response ) => {
+            if ( response.statusCode < 200 || response.statusCode > 299 ) {
+                const statusError = new Error( `Failed to load ${ requestUrl }, status code: ${ response.statusCode }` );
+                statusError.statusCode = response.statusCode;
+                response.resume();
+                reject( statusError );
+
+                return;
+            }
+
+            const body = [];
+            response.on( 'data', ( chunk ) => {
+                body.push( chunk );
+            } );
+            response.on( 'end', () => {
+                resolve( body.join( '' ) );
+            } );
+        } );
+
+        request.on( 'error', ( requestError ) => {
+            reject( requestError );
+        } );
+
+        request.setTimeout( REQUEST_TIMEOUT_MS, () => {
+            request.destroy( new Error( `Timed out after ${ REQUEST_TIMEOUT_MS }ms loading ${ requestUrl }` ) );
+        } );
+    } );
+};
+
+const isRetryable = function isRetryable( requestError ) {
+    if ( typeof requestError.statusCode === 'number' ) {
+        return requestError.statusCode >= 500;
+    }
+
+    return true;
+};
+
+const promiseGet = async function promiseGet( requestUrl, headers = false ) {
+    let lastError;
+
+    for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt = attempt + 1 ) {
+        try {
+            return await attemptGet( requestUrl, headers );
+        } catch ( requestError ) {
+            lastError = requestError;
+
+            if ( attempt >= MAX_ATTEMPTS || !isRetryable( requestError ) ) {
+                break;
+            }
+
+            await sleep( RETRY_BACKOFF_MS * attempt );
+        }
+    }
+
+    throw lastError;
+};
+
+const mapWithConcurrency = async function mapWithConcurrency( items, limit, worker ) {
+    let cursor = 0;
+
+    const runNext = async function runNext() {
+        while ( cursor < items.length ) {
+            const index = cursor;
+            cursor = cursor + 1;
+            await worker( items[ index ] );
+        }
+    };
+
+    const runners = [];
+    for ( let i = 0; i < Math.min( limit, items.length ); i = i + 1 ) {
+        runners.push( runNext() );
+    }
+
+    await Promise.all( runners );
+};
+
+const run = async function run() {
+    const gamesResponse = await promiseGet( `https://${ API_HOST }/games`, {
+        Authorization: `Bearer ${ process.env.API_TOKEN }`,
+    } );
+    const identifiers = JSON.parse( gamesResponse ).data.map( ( gameConfig ) => {
+        return gameConfig.identifier;
+    } );
+
+    const qualifying = [];
+
+    // Mirror build.js: a game qualifies when the posts endpoint returns at
+    // least one row. On a per-game probe error we FAIL the whole fingerprint
+    // (throw) rather than guess — a wrong fingerprint could wrongly skip a
+    // deploy, so an unknowable state must fall through to "deploy anyway".
+    const thunks = identifiers.map( ( identifier ) => {
+        return async () => {
+            const postsResponse = await promiseGet( `https://${ API_HOST }/${ identifier }/posts?limit=1` );
+            const posts = JSON.parse( postsResponse ).data;
+
+            if ( Array.isArray( posts ) && posts.length > 0 ) {
+                qualifying.push( identifier );
+            }
+        };
+    } );
+
+    await mapWithConcurrency( thunks, REQUEST_CONCURRENCY, ( thunk ) => {
+        return thunk();
+    } );
+
+    qualifying.sort();
+
+    const digest = crypto.createHash( 'sha256' )
+        .update( qualifying.join( '\n' ) )
+        .digest( 'hex' );
+
+    process.stdout.write( digest );
+};
+
+run()
+    .catch( ( fingerprintError ) => {
+        process.stderr.write( `Fingerprint failed: ${ fingerprintError.message }\n` );
+        process.exitCode = 1;
+    } );


### PR DESCRIPTION
## What
Adds an hourly `schedule:` trigger to the deploy workflow so a game that only just gained its first posts goes live automatically, instead of staying hidden until the next push.

## Why it works with no other changes
`scripts/build.js` already re-fetches the full game list from the API on every run and drops any game with zero posts (the `posts?limit=1` probe). So a previously-skipped game reappears on the next build automatically — the only thing missing was a trigger between commits.

## No-churn guard
The build stamps `version: Date.now()` into every page + the service-worker, so an unconditional hourly deploy would bump the SW and re-upload everything every hour even when nothing changed (clients would see an "update" hourly).

To avoid that, scheduled runs are gated on a fingerprint of the set of games-that-have-posts (`scripts/games-fingerprint.js`, mirroring build.js's filter), cached across runs via `actions/cache`:
- Scheduled run + unchanged set (cache hit) → **skip** build & deploy.
- Push or manual `workflow_dispatch` → **always** deploy.
- Fingerprint can't be computed → **fall through and deploy** (fail-safe; never skip on uncertainty).
